### PR TITLE
TSV-402: Deprecate versions of microservice-bootstrap that do not log…

### DIFF
--- a/deprecated-dependencies.json
+++ b/deprecated-dependencies.json
@@ -14,6 +14,7 @@
         { "organisation" : "uk.gov.hmrc", "name" : "http-caching-client", "range" : "(,5.2.0)", "reason" : "Auditing upgrade", "from" : "2015-11-23" },
         { "organisation" : "uk.gov.hmrc", "name" : "frontend-bootstrap", "range" : "(,7.10.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
         { "organisation" : "uk.gov.hmrc", "name" : "microservice-bootstrap", "range" : "(,5.8.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
+        { "organisation" : "uk.gov.hmrc", "name" : "microservice-bootstrap", "range" : "(,5.10.0)", "reason" : "Added error logging (with stacktrace) for downstream exceptions. A nice-to-have for peak periods", "from" : "2017-12-01" },
         { "organisation" : "uk.gov.hmrc", "name" : "play-partials", "range" : "(,5.2.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
         { "organisation" : "uk.gov.hmrc", "name" : "play-authorised-frontend", "range" : "(,6.2.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
         { "organisation" : "uk.gov.hmrc", "name" : "play-authorisation", "range" : "(,4.2.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },

--- a/deprecated-dependencies.json
+++ b/deprecated-dependencies.json
@@ -14,7 +14,7 @@
         { "organisation" : "uk.gov.hmrc", "name" : "http-caching-client", "range" : "(,5.2.0)", "reason" : "Auditing upgrade", "from" : "2015-11-23" },
         { "organisation" : "uk.gov.hmrc", "name" : "frontend-bootstrap", "range" : "(,7.10.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
         { "organisation" : "uk.gov.hmrc", "name" : "microservice-bootstrap", "range" : "(,5.8.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
-        { "organisation" : "uk.gov.hmrc", "name" : "microservice-bootstrap", "range" : "(,5.10.0)", "reason" : "Added error logging (with stacktrace) for downstream exceptions. A nice-to-have for peak periods", "from" : "2017-12-01" },
+        { "organisation" : "uk.gov.hmrc", "name" : "microservice-bootstrap", "range" : "(,5.11.0)", "reason" : "Added error logging (with stacktrace) for downstream exceptions. A nice-to-have for peak periods", "from" : "2017-12-01" },
         { "organisation" : "uk.gov.hmrc", "name" : "play-partials", "range" : "(,5.2.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
         { "organisation" : "uk.gov.hmrc", "name" : "play-authorised-frontend", "range" : "(,6.2.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },
         { "organisation" : "uk.gov.hmrc", "name" : "play-authorisation", "range" : "(,4.2.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-13" },


### PR DESCRIPTION
… downstream errors with a stacktrace. Generous end date as this is non-essential before peak period, so if any future releases of microservice-bootstrap are considered essential then feel free to overwrite this version and date