### PR TITLE
Bump play-ui version

### DIFF
--- a/deprecated-dependencies.json
+++ b/deprecated-dependencies.json
@@ -26,7 +26,7 @@
         { "organisation" : "uk.gov.hmrc", "name" : "mongo-lock", "range" : "(,4.0.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-27" },
         { "organisation" : "uk.gov.hmrc", "name" : "reactivemongo-test", "range" : "(,2.0.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-27" },
         { "organisation" : "org.reactivemongo", "name" : "reactivemongo", "range" : "(,99.99.99)", "reason" : "ReactiveMongo for Zombie Connections upgrade", "from" : "2016-08-08" },
-        { "organisation" : "uk.gov.hmrc", "name" : "play-ui", "range" : "(,7.0.0)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-27" },
+        { "organisation" : "uk.gov.hmrc", "name" : "play-ui", "range" : "(,7.0.1)", "reason" : "Play 2.5 upgrade", "from" : "2017-03-27" },
         { "organisation" : "uk.gov.hmrc", "name": "secure", "range": "(,7.1.0)", "reason": "Security update in bouncy-castle library", "from": "2017-04-01" },
         { "organisation" : "uk.gov.hmrc", "name": "crypto", "range": "(,4.2.0)", "reason": "Play 2.5 upgrade", "from": "2017-03-27" },
         { "organisation" : "uk.gov.hmrc", "name": "json-encryption", "range": "(,3.2.0)", "reason": "Play 2.5 upgrade", "from": "2017-03-27" },


### PR DESCRIPTION
A hotfix has been released for play-ui. This PR bumps the required bobby version to this version.

Related PR on play-ui https://github.com/hmrc/play-ui/pull/71